### PR TITLE
[H-01] Add deployment contracts to public repo for better deployment clarity

### DIFF
--- a/contracts/deploy/UupsPlaceholder.sol
+++ b/contracts/deploy/UupsPlaceholder.sol
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.21;
+
+import { UUPSUpgradeable } from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
+import { AccessControlUpgradeable } from "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
+
+contract UupsPlaceholder is AccessControlUpgradeable, UUPSUpgradeable {
+
+  /// @custom:oz-upgrades-unsafe-allow constructor
+  constructor() {
+    _disableInitializers();
+  }
+
+  function initialize(address owner) public initializer {
+    __AccessControl_init();
+    _grantRole(DEFAULT_ADMIN_ROLE, owner);
+    __UUPSUpgradeable_init();
+  }
+
+  function _authorizeUpgrade(address newImplementation) internal override onlyRole(DEFAULT_ADMIN_ROLE) {
+  }
+
+  function version() external pure returns(uint256) {
+    return 0;
+  }
+}


### PR DESCRIPTION
As part of the audit, it was found that we are not initializing the contract properly:

[H-01] FundsManagerLogic#initialize - Initialization Deadlock in FundsManagerLogic Contract
**Description**

The FundsManagerLogic contract contains a critical initialization deadlock that prevents
the contract from being initialized after deployment. The initialize function requires
the caller to have the DEFAULT_ADMIN_ROLE, but there is no mechanism to grant this role
to any address before initialization occurs.

**Recommendation**
Remove the onlyRole(DEFAULT_ADMIN_ROLE) modifier from the initialize function and
grant the role during initialization

**Solution**
The UupsPlaceholder contract is already doing the initialization. We are adding the contract to the public repo and to the audit so it's clear that this issue is already solved